### PR TITLE
Script now successfully downloads x86 stage3

### DIFF
--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -389,6 +389,7 @@ create() {
 
 		echo "not found."
 
+    # make unique variables for x86 and amd64 since stage3 url are different
     echo -n "Generating strings to run... "
     if [ $ARCH == 'x86' ]; then
       STAGE3SED="s/.*stage3-${SUBARCH}-\(........\)\.tar\.bz2.*/\1/p"


### PR DESCRIPTION
Fixed faulty logic with architecture (amd64 always ends up as default).
Since script didn't consider "subarch" (i386, i686) of x86 it was unable to download stage3 files for x86. If x86 is chosen as ARCH, SUBARCH defaults to output of `uname -m` but also prompts user for input (if user want to change).
