### PR TITLE
Fix tty comment typo + add comments about /dev/console & /dev/tty

### DIFF
--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -286,11 +286,11 @@ write_lxc_configuration() {
 	# /dev/pts/*
 	lxc.cgroup.devices.allow = c 136:* rw
 	lxc.cgroup.devices.allow = c 5:2 rw
-	# /dev/tty{1,2}
-	lxc.cgroup.devices.allow = c 4:1 rwm
+	# /dev/tty{0,1}
 	lxc.cgroup.devices.allow = c 4:0 rwm
-	lxc.cgroup.devices.allow = c 5:0 rwm
-	lxc.cgroup.devices.allow = c 5:1 rwm
+	lxc.cgroup.devices.allow = c 4:1 rwm
+	lxc.cgroup.devices.allow = c 5:0 rwm # /dev/tty
+	lxc.cgroup.devices.allow = c 5:1 rwm # /dev/console
 	# /dev/net/tun
 	lxc.cgroup.devices.allow = c 10:200 rwm
 


### PR DESCRIPTION
device 4:0 => /dev/tty0
device 4:1 => /dev/tty1
