### PR TITLE
Allow overriding of mirror

### DIFF
--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -72,6 +72,7 @@ else
 fi
 ARCHVARIANT=${ARCHVARIANT:-}
 CONFFILE="${UTSNAME}.conf"
+MIRROR=${MIRROR:-http://distfiles.gentoo.org}
 
 # These paths are within the container so do not need to obey configure prefixes
 INITTAB="/etc/inittab"
@@ -349,7 +350,7 @@ fetch_template() {
 			fi
 
 			# base stage3 URL
-			STAGE3URL="http://distfiles.gentoo.org/releases/${ARCH}/autobuilds"
+			STAGE3URL="${MIRROR}/releases/${ARCH}/autobuilds"
 
 			# get latest-stage3....txt file for subpath
 			echo -n "Determining path to latest ${DISTRO} ${ARCH}${ARCHVARIANT} stage3 archive..."
@@ -391,7 +392,7 @@ fetch_template() {
 			echo "done."
 			echo -n "Downloading ${DISTRO} portage (software database) snapshot..."
 			rm -f ${CACHE}/portage-latest.tar.bz2 > /dev/null 2>&1
-			${WGET} -O ${CACHE}/portage-latest.tar.bz2 http://distfiles.gentoo.org/snapshots/portage-latest.tar.bz2 > /dev/null 2>&1
+			${WGET} -O ${CACHE}/portage-latest.tar.bz2 ${MIRROR}/snapshots/portage-latest.tar.bz2 > /dev/null 2>&1
 			if [ ! $? -eq 0 ]; then
 				echo "failed."
 				return 1
@@ -477,6 +478,14 @@ configure() {
 		echo ""
 		stty echo
 		echo ""
+
+		# choose the mirror
+		echo -n "Which mirror to use for stage3 and Portage archive ? [${MIRROR}]"
+		read _MIRROR_
+		if [ ! -z "${_MIRROR_}" ]; then
+			MIRROR=${_MIRROR_}
+		fi
+
 	fi
 
 	CONFFILE="${UTSNAME}.conf"
@@ -653,6 +662,9 @@ help() {
 		-p GUESTROOTPASS : password for root account
 			Env. Var.: GUESTROOTPASS
 			Current/Default: ${GUESTROOTPASS}
+		-m MIRROR : mirror for stage3 and Portage archive
+			Env. Var.: MIRROR
+			Current/Default: ${MIRROR}
 		-C CUSTOMURL : URL for a custom tarball
 			Env. Var.: CUSTOMURL
 			Current/Default: ${CUSTOMURL}
@@ -727,7 +739,7 @@ fi
 CACHE="/var/cache/lxc/${DISTRO}"
 
 OPTIND=2
-while getopts "i:g:n:u:a:C:p:q" opt; do
+while getopts "i:g:n:u:a:C:p:m:q" opt; do
 	case $opt in
 		i) IPV4=$OPTARG ;;
 		g) GATEWAY=$OPTARG ;;
@@ -736,6 +748,7 @@ while getopts "i:g:n:u:a:C:p:q" opt; do
 		a) ARCH=$OPTARG ;;
 		C) CUSTOMURL=$OPTARG;;
 		p) GUESTROOTPASS=$OPTARG ;;
+		m) MIRROR=$OPTARG ;;
 		q) QUIET=Yes ;;
 		\?) ;;
 	esac


### PR DESCRIPTION
This commit allows overriding the mirror selection via the `$MIRROR` environment variable, for faster downloads outside of US. A new command line option `-m` is added.

PS: From a quick grep it seems the `$CUSTOMURL` option is never used. Maybe it is kept for a reason?
