### PR TITLE
Override root's umask with an "always correct" one

### DIFF
--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -78,6 +78,9 @@ MIRROR=${MIRROR:-http://distfiles.gentoo.org}
 INITTAB="/etc/inittab"
 FSTAB="/etc/fstab"
 
+# Ensure strict root's umask doesen't render the VM unusable
+umask 022
+
 ################################################################################
 #                    DISTRO custom configuration files
 ################################################################################


### PR DESCRIPTION
Having a strict umask (such as 077) typically results in e.g. /etc/resolv.conf being mode 600 and networking not working for anyone but root. Or even worse: the rootfs directory is created mode 700 and then everything (except by root) errors out.
