### PR TITLE
Fix a possible populate_dev error

### DIFF
--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -85,7 +85,6 @@ umask 022
 #                    DISTRO custom configuration files
 ################################################################################
 
-# populate /dev
 populate_dev() {
 	# we silence errors as newer stage3s appear to include device files
 	DEV="${ROOTFS}/dev"


### PR DESCRIPTION
As a comment within populate_dev() states, we silence errors from mknod/mkdir calls, yet check populate_dev()'s return status in create().

This obviosly errors out if .../dev/net/tun already exists.
