### PR TITLE
Misc fixes

### DIFF
--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -269,6 +269,7 @@ write_lxc_configuration() {
 	# disabled for security, see http://blog.bofh.it/debian/id_413
 	#lxc.mount.entry=sys `readlink -f ${ROOTFS}/sys` sysfs defaults 0 0
 	lxc.mount.entry=shm `readlink -f ${ROOTFS}/dev/shm` tmpfs rw,nosuid,nodev,noexec,relatime 0 0
+	lxc.mount.entry=tmp `readlink -f ${ROOTFS}/tmp` tmpfs rw,nosuid,nodev,noexec 0 0
 	lxc.mount.entry=run `readlink -f ${ROOTFS}/run` tmpfs rw,nosuid,nodev,relatime,mode=755 0 0
 
 	# console access


### PR DESCRIPTION
Use read's built-in readline capabilities, present the default to the user for editing
I think Bash-isms are the way to go since this script (and all scripts shipped with LXC) rely on Bash.

removed the destroy() function since "destroying" a container is trivial and the function didn't work anyway.
- moved /tmp onto tmpfs

One more thing: is it necesary for $? checks to return to the calling function or can we stop the script entirely? This would make the code _A lot_ shorter.
