### PR TITLE
Turns out they aren't redundant after all.

### DIFF
--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -696,8 +696,7 @@ create()
 	printf "Unpacking filesystem from %s to %s ... " "$STAGE3_TARBALL" "$ROOTFS"
 	mkdir -p "$ROOTFS"
 
-	# also exclude redundant .keep files
-	tar --exclude .keep -xpf "$STAGE3_TARBALL" -C "$ROOTFS"
+	tar -xpf "$STAGE3_TARBALL" -C "$ROOTFS"
 	if [[ $? -ne 0 ]]; then
 		printf "FAILED.\n"
 		return 1


### PR DESCRIPTION
They are a hack (atleast that is how I see it) around portage
removing the directory when the last package owning it is unmerged.
But the directory should still exist (e.g. /var/log).
