### PR TITLE
summer fixes 1/?

### DIFF
--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -999,22 +999,17 @@ create()
 		|| die 1 "Error: Failed to set guest root password\n"
 
 	cat <<-EOF
-	All done!
+	all done! (Report bugs to https://github.com/globalcitizen/lxc-gentoo/issues)
 
-	You can run your container with the 'lxc-start -f "$CONFFILE" -n "$NAME"'
-	For host-side networking setup info, see "$ROOTFS/etc/conf.d/net"
+	For host-side networking setup info and information on running containers of
+	other architectures, see the README included with lxc-gentoo.
 
-	To enter your container for setup WITHOUT running it, try:
-	   mount -t proc proc "$ROOTFS/proc"
-	   mount -o bind /dev "$ROOTFS/dev"
-	   chroot "$ROOTFS" /bin/bash
-	   export PS1="(${NAME}) \$PS1"
-	 (${NAME}) #   <-- you are now in the guest
-	... or, start it on the current console with:
-	   lxc-start -f "$CONFFILE" -n "$NAME"
-	... or, start it elsewhere then use 'lxc-console -n "$NAME"' for a shell
-	
-	(Report bugs to https://github.com/globalcitizen/lxc-gentoo/issues )";
+	You can now run the container on the current terminal:
+	 .. 'lxc-start --foreground --rcfile "$CONFFILE" --name "$NAME"'
+	or start it elsewhere/in the background then use
+	 .. 'lxc-console --name "$NAME"' for a root shell
+	you can stop it with 'shutdown -h now' inside the container or on the host:
+	 .. 'lxc-stop [--kill] --name "$NAME"'
 	EOF
 }
 

--- a/lxc-gentoo
+++ b/lxc-gentoo
@@ -407,6 +407,9 @@ write_lxc_configuration()
 	# root filesystem location
 	lxc.rootfs = $(readlink -f "$ROOTFS")
 
+	# recent LXC tools default to auto-mounting tmpfs on /dev
+	lxc.autodev = 0
+
 	# mounts that allow us to drop CAP_SYS_ADMIN
 	lxc.mount.entry=proc proc proc ro,nodev,noexec,nosuid 0 0
 	# disabled for security, see http://blog.bofh.it/debian/id_413


### PR DESCRIPTION
The first is for (I suppose the /dev tmpfs is for systemd or w/e):

lxc-start --foreground --rcfile awdw.conf --name awdw
lxc-start: conf.c: mount_entry: 1722 No such file or directory - failed to mount 'shm' on '/var/lib/lxc/rootfs/dev/shm'
lxc-start: conf.c: lxc_setup: 3843 failed to setup the mount entries for 'awdw'
lxc-start: start.c: do_start: 699 failed to setup the container
lxc-start: sync.c: __sync_wait: 51 invalid sequence number 1. expected 2
lxc-start: start.c: __lxc_start: 1164 failed to spawn 'awdw'
lxc-start: lxc_start.c: main: 344 The container failed to start.
lxc-start: lxc_start.c: main: 348 Additional information can be obtained by setting the --logfile and --logpriority options.

I think it would be great if the blocks of text at lines 270 and 440 were [re]moved to README
and that at 1050-1080 moved to line 1024 as the quick usage help is imo more helpful than the other wall of text. y/n?
